### PR TITLE
Allow rack 2.0

### DIFF
--- a/capybara-webmock.gemspec
+++ b/capybara-webmock.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "capybara", "~> 2.4"
-  spec.add_dependency "rack", "~> 1.4"
+  spec.add_dependency "rack", ">= 1.4"
   spec.add_dependency "rack-proxy", "0.6.0"
 
   spec.add_development_dependency "bundler", "~> 1.13"


### PR DESCRIPTION
This would allow up-to-date Ruby on Rails apps that are using rack 2.0.1 to use the gem.