### PR TITLE
Handling pid from Webmock, tracking proxied requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,25 +57,15 @@ Then in your RSpec configuration:
 # spec/spec_helper.rb
 
 RSpec.configure do |config|
-  config.before(:suite) do
-    Capybara::Webmock.start
+  config.before(:each) do |example|
+    if example.metadata[:type] == :feature
+      Capybara::Webmock.start
+    end
   end
 
   config.after(:suite) do
     Capybara::Webmock.stop
   end
-end
-```
-
-Or, your Cucumber configuration:
-
-```ruby
-# features/support/env.rb
-
-Capybara::Webmock.start
-
-at_exit do
-  Capybara::Webmock.stop
 end
 ```
 
@@ -107,6 +97,15 @@ with the following configuration:
 
 ```ruby
 Capybara::Webmock.port_number = 8080
+```
+
+During each test, you can inspect the list of proxied requests:
+
+```ruby
+it 'makes a request to /somewhere when the user visits the page' do
+  visit "/some-page"
+  expect(Capybara::Webmock.proxied_requests.any?{|req| req.path == "/somewhere" }).to be
+end
 ```
 
 ### Development

--- a/lib/capybara/webmock.rb
+++ b/lib/capybara/webmock.rb
@@ -1,26 +1,53 @@
+require 'open3'
+require 'fileutils'
 require 'capybara'
 require 'selenium-webdriver'
 require 'capybara/webmock/version'
 require 'capybara/webmock/proxy'
+require 'capybara/webmock/proxied_request'
 
 module Capybara
   module Webmock
     class << self
-
-      attr_accessor :port_number
+      attr_accessor :port_number, :pid_file, :kill_timeout
 
       def start
-        log_file   = File.join('log', 'test.log')
-        gem_path   = File.dirname(__FILE__)
-        proxy_file = File.join(gem_path, 'webmock', 'config.ru')
-        IO.popen("PROXY_PORT_NUMBER=#{port_number} rackup #{proxy_file} >> #{log_file} 2>&1")
+        if @pid.nil?
+          kill_old_process
+          gem_path   = File.dirname(__FILE__)
+          proxy_file = File.join(gem_path, 'webmock', 'config.ru')
+          stdin, stdout, wait_thr = Open3.popen2e({ "PROXY_PORT_NUMBER" => port_number.to_s }, "rackup", proxy_file)
+          stdin.close
+          @stdout = stdout
+          @pid = wait_thr[:pid]
+          write_pid_file
+        end
+
+        get_output_nonblocking
+        @output_buf = ""
+      end
+
+      def proxied_requests
+        @output_buf += get_output_nonblocking
+
+        matches = @output_buf.sub(/\n[^\n]+\z/, '').split("\n").map do |line|
+          match = /\A(.+) -> (.+)\Z/.match(line)
+          next nil unless match
+          match.captures
+        end
+
+        matches.compact.map{ |raw_referrer, raw_uri| ProxiedRequest.new(raw_referrer, raw_uri) }
       end
 
       def stop
-        if File.exist?(Capybara::Webmock::Proxy::PID_FILE)
-          rack_pid = File.read(Capybara::Webmock::Proxy::PID_FILE).to_i
-          Process.kill('HUP', rack_pid)
-        end
+        return if @pid.nil?
+
+        @stdout.close
+        kill_process(@pid)
+        remove_pid_file
+
+        @pid = nil
+        @stdout = nil
       end
 
       def firefox_profile
@@ -34,25 +61,86 @@ module Capybara
         profile
       end
 
-      def chrome_switches
-        ["--proxy-server=127.0.0.1:#{port_number}"]
+      def chrome_options
+        { args: "proxy-server=127.0.0.1:#{port_number}" }
       end
 
       def phantomjs_options
         ["--proxy=127.0.0.1:#{port_number}"]
+      end
+
+      private
+
+      def get_output_nonblocking
+        buf = ""
+
+        while true
+          begin
+            output = @stdout.read_nonblock(1024)
+            break if output == ""
+            buf += output
+          rescue IO::WaitReadable
+            break
+          end
+        end
+
+        buf
+      end
+
+      def kill_old_process
+        return unless File.exists?(pid_file)
+        old_pid = File.read(pid_file).to_i
+        kill_process(old_pid) if old_pid > 1
+        remove_pid_file
+      end
+
+      def kill_process(pid)
+        Process.kill('HUP', pid) if process_alive?(pid)
+
+        (1..kill_timeout).each do
+          sleep(1) if process_alive?(pid)
+        end
+
+        Process.kill('KILL', pid) if process_alive?(pid)
+
+        (1..kill_timeout).each do
+          sleep(1) if process_alive?(pid)
+        end
+
+        if process_alive?(pid)
+          raise "Unable to kill capybara-webmock process with PID #{pid}"
+        end
+      end
+
+      def process_alive?(pid)
+        !!Process.kill(0, pid) rescue false
+      end
+
+      def write_pid_file
+        raise "Pid file #{pid_file} already exists" if File.exists?(pid_file)
+        FileUtils.mkdir_p(File.dirname(pid_file))
+        File.write(pid_file, @pid.to_s)
+      end
+
+      def remove_pid_file
+        File.delete(pid_file) if File.exists?(pid_file)
       end
     end
   end
 end
 
 Capybara::Webmock.port_number ||= 9292
+Capybara::Webmock.pid_file ||= File.join('tmp', 'pids', 'capybara_webmock_proxy.pid')
+Capybara::Webmock.kill_timeout ||= 5
 
 Capybara.register_driver :capybara_webmock do |app|
   Capybara::Selenium::Driver.new(app, browser: :firefox, profile: Capybara::Webmock.firefox_profile)
 end
 
 Capybara.register_driver :capybara_webmock_chrome do |app|
-  Capybara::Selenium::Driver.new(app, browser: :chrome, switches: Capybara::Webmock.chrome_switches)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: {
+    chromeOptions: Capybara::Webmock.chrome_options 
+  })
 end
 
 Capybara.register_driver :capybara_webmock_poltergeist do |app|

--- a/lib/capybara/webmock.rb
+++ b/lib/capybara/webmock.rb
@@ -1,5 +1,6 @@
 require 'open3'
 require 'fileutils'
+require 'socket'
 require 'capybara'
 require 'selenium-webdriver'
 require 'capybara/webmock/version'
@@ -9,7 +10,7 @@ require 'capybara/webmock/proxied_request'
 module Capybara
   module Webmock
     class << self
-      attr_accessor :port_number, :pid_file, :kill_timeout
+      attr_accessor :port_number, :pid_file, :kill_timeout, :start_timeout
 
       def start
         if @pid.nil?
@@ -21,6 +22,7 @@ module Capybara
           @stdout = stdout
           @pid = wait_thr[:pid]
           write_pid_file
+          wait_for_proxy_start
         end
 
         get_output_nonblocking
@@ -70,6 +72,23 @@ module Capybara
       end
 
       private
+
+      def wait_for_proxy_start
+        connected = false
+        (1..start_timeout).each do
+          begin
+            Socket.tcp("127.0.0.1", port_number, connect_timeout: 1) {}
+            connected = true
+            break
+          rescue => e
+            sleep 1
+          end
+        end
+
+        unless connected
+          raise "Unable to connect to capybara-webmock proxy on #{port_number}"
+        end
+      end
 
       def get_output_nonblocking
         buf = ""
@@ -132,6 +151,7 @@ end
 Capybara::Webmock.port_number ||= 9292
 Capybara::Webmock.pid_file ||= File.join('tmp', 'pids', 'capybara_webmock_proxy.pid')
 Capybara::Webmock.kill_timeout ||= 5
+Capybara::Webmock.start_timeout ||= 5
 
 Capybara.register_driver :capybara_webmock do |app|
   Capybara::Selenium::Driver.new(app, browser: :firefox, profile: Capybara::Webmock.firefox_profile)

--- a/lib/capybara/webmock/config.ru
+++ b/lib/capybara/webmock/config.ru
@@ -1,12 +1,5 @@
 require 'rack'
 require 'capybara/webmock/proxy'
 
-at_exit { Capybara::Webmock::Proxy.remove_pid }
-
-trap('SIGHUP') {
-  Capybara::Webmock::Proxy.remove_pid
-  exit!
-}
-
 app = Capybara::Webmock::Proxy.new(Process.pid)
 Rack::Handler::WEBrick.run(app, Port: ENV.fetch('PROXY_PORT_NUMBER', 9292))

--- a/lib/capybara/webmock/proxied_request.rb
+++ b/lib/capybara/webmock/proxied_request.rb
@@ -1,0 +1,25 @@
+require 'uri'
+
+module Capybara
+  module Webmock
+    class ProxiedRequest
+      attr_reader :referrer, :uri
+
+      def initialize(raw_referrer, raw_uri)
+        @referrer = raw_referrer == "-" ? nil : URI.parse(raw_referrer)
+        @uri = URI.parse(raw_uri)
+      end
+
+      def fragment; @uri.fragment; end
+      def host; @uri.host; end
+      def hostname; @uri.hostname; end
+      def password; @uri.password; end
+      def path; @uri.path; end
+      def port; @uri.port; end
+      def query; @uri.query; end
+      def scheme; @uri.scheme; end
+      def user; @uri.user; end
+      def userinfo; @uri.userinfo; end
+    end
+  end
+end

--- a/lib/capybara/webmock/proxy.rb
+++ b/lib/capybara/webmock/proxy.rb
@@ -2,52 +2,28 @@ require 'rack/proxy'
 require 'capybara/webmock'
 
 class Capybara::Webmock::Proxy < Rack::Proxy
-  PID_FILE = File.join('tmp', 'pids', 'capybara_webmock_proxy.pid')
-
-  def initialize(pid)
-    write_pid(pid)
-    ensure_log_exists
-  end
+  ALLOWED_HOSTS = allowed_hosts = ['127.0.0.1', 'localhost', %r{(.*\.|\A)lvh.me}]
 
   def perform_request(env)
     request = Rack::Request.new(env)
-    allowed_urls = ['127.0.0.1', 'localhost', %r{(.*\.|\A)lvh.me}]
 
-    if allowed_url?(allowed_urls, request.host)
+    if allowed_host?(request.host)
       super(env)
     else
       ['200', {'Content-Type' => 'text/html'}, ['']]
     end
   end
 
-  def self.remove_pid
-    File.delete(PID_FILE) if File.exist?(PID_FILE)
-  end
-
   private
 
-  def allowed_url?(urls, host)
-    case urls
-    when Array
-      urls.any? { |url| allowed_url?(url, host) }
-    when Regexp
-      urls =~ host
-    when String
-      urls == host
+  def allowed_host?(host)
+    ALLOWED_HOSTS.any? do |allowed_host|
+      case allowed_host
+      when Regexp
+        allowed_host =~ host
+      when String
+        allowed_host == host
+      end
     end
-  end
-
-  def write_pid(pid)
-    tmp_dir = 'tmp'
-    pid_dir = File.join(tmp_dir, 'pids')
-    Dir.mkdir(tmp_dir) unless Dir.exist?(tmp_dir)
-    Dir.mkdir(pid_dir) unless Dir.exist?(pid_dir)
-    File.write(PID_FILE, pid)
-  end
-
-  def ensure_log_exists
-    log_file = File.join('log', 'test.log')
-    Dir.mkdir('log') unless Dir.exist?('log')
-    File.open(log_file, 'a') { |f| f.write "" }
   end
 end

--- a/spec/capybara/proxy_spec.rb
+++ b/spec/capybara/proxy_spec.rb
@@ -2,54 +2,7 @@ require 'spec_helper'
 require 'ostruct'
 
 describe Capybara::Webmock::Proxy do
-  it "PID_FILE to equal the correct value" do
-    expect(Capybara::Webmock::Proxy::PID_FILE).to eq 'tmp/pids/capybara_webmock_proxy.pid'
-  end
-
-  context 'pid files' do
-    before do
-      Capybara::Webmock::Proxy.new('')
-    end
-
-    after do
-      if File.exist?(Capybara::Webmock::Proxy::PID_FILE)
-        File.delete(Capybara::Webmock::Proxy::PID_FILE)
-      end
-    end
-
-    it '#initialize' do
-      expect {
-        Capybara::Webmock::Proxy.new('1234567')
-      }.to change {
-        File.read(Capybara::Webmock::Proxy::PID_FILE)
-      }.from('').to('1234567')
-    end
-
-    it '.remove_pid' do
-      expect {
-        Capybara::Webmock::Proxy.remove_pid
-      }.to change {
-        File.exist?(Capybara::Webmock::Proxy::PID_FILE)
-      }.from(true).to(false)
-    end
-  end
-
-  context 'log files' do
-    after do
-      Capybara::Webmock::Proxy.remove_pid
-    end
-
-    it 'ensures a log file' do
-      expect {
-        Capybara::Webmock::Proxy.new ''
-      }.to change {
-        File.exist?(File.join('log', 'test.log'))
-      }.from(false).to(true)
-    end
-  end
-
   context '#perform_requests' do
-
     def new_env(host)
       {
         "REQUEST_METHOD" => "GET",
@@ -61,29 +14,19 @@ describe Capybara::Webmock::Proxy do
 
     let(:proxy) { Capybara::Webmock::Proxy.new('123456') }
 
-    after do
-      Capybara::Webmock::Proxy.remove_pid
+    before do
+      allow_any_instance_of(Rack::Proxy).to receive(:perform_request).and_return(['400', {foo: :bar}, ['baz']])
     end
 
-    it 'returns an empty response when unknown domain' do
+    it 'returns an empty response when unknown host' do
       env = new_env("notlvh.me")
       expect(proxy.perform_request(env)).to eq ["200", {"Content-Type"=>"text/html"}, [""]]
     end
 
-    context 'with allowed hosts' do
-      before do
-        stubbed_http = instance_double(Net::HTTP)
-        stubbed_response = OpenStruct.new(code: '200', headers: [], body: 'good response')
-        allow(stubbed_http).to receive(:read_timeout=)
-        allow(stubbed_http).to receive(:start).and_return(stubbed_response)
-        expect(Net::HTTP).to receive(:new).and_return(stubbed_http)
-      end
-
-      %w{lvh.me sub.lvh.me localhost 127.0.0.1}.each do |host|
-        it "allows #{host}" do
-          env = new_env(host)
-          expect(proxy.perform_request(env)).to eq ["200", [], ["good response"]]
-        end
+    %w{lvh.me sub.lvh.me localhost 127.0.0.1}.each do |host|
+      it "allows known #{host}" do
+        env = new_env(host)
+        expect(proxy.perform_request(env)).to eq(['400', {foo: :bar}, ['baz']])
       end
     end
   end

--- a/spec/capybara/webmock_spec.rb
+++ b/spec/capybara/webmock_spec.rb
@@ -1,5 +1,6 @@
 require 'open3'
 require 'fileutils'
+require 'socket'
 
 require 'spec_helper'
 
@@ -111,6 +112,8 @@ describe Capybara::Webmock do
       allow(File).to receive(:delete) { |path| written.delete(path) }
       allow(File).to receive(:write) { |path| written.push(path) }
       allow(File).to receive(:exists?) { |path| written.include?(path) }
+
+      allow(Socket).to receive(:tcp)
 
       killed = []
       allow(Process).to receive(:kill) do |signal, pid|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,5 +19,6 @@ RSpec.configure do |config|
     Capybara::Webmock.port_number = 9292
     Capybara::Webmock.pid_file = File.join('tmp', 'pids', 'capybara_webmock_proxy.pid')
     Capybara::Webmock.kill_timeout = 5
+    Capybara::Webmock.start_timeout = 5
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,8 +12,12 @@ require "capybara/webmock"
 
 RSpec.configure do |config|
   config.after(:each) do
+    Capybara::Webmock.instance_variables.each do |var|
+      Capybara::Webmock.send(:remove_instance_variable, var)
+    end
+
     Capybara::Webmock.port_number = 9292
-    log_file = File.join(Dir.pwd, 'log', 'test.log')
-    File.delete(log_file) if File.exist?(log_file)
+    Capybara::Webmock.pid_file = File.join('tmp', 'pids', 'capybara_webmock_proxy.pid')
+    Capybara::Webmock.kill_timeout = 5
   end
 end


### PR DESCRIPTION
So I started out thinking "I really wish I could see which requests were proxied from within my capybara specs", and ended up with this PR, which rewrites large portions of `capybara-webmock`.

This is definitely a doozy, but I think I have a good reason behind each change I made:

* Because I want to capture stdout from the process in a controlled way, I replaced `IO.popen` with `Popen3`.
* `Popen3` also happens to let me easily access the PID of the spawned process, which lets me move the pidfile logic out of `Proxy` and into `Webmock`, and simplify it a little.
* While I was at it, I also made the pidfile recovery a little more tolerant of dead pidfiles; in the original implementation, the `Process.kill('HUP', rack_pid)` line would crash if the given PID was no longer running.
* Additionally, I let the kill mechanism wait a bit for the HUP to kick in before it tries to start the new server, to avoid port conflicts. If the HUP doesn't work, it tries a KILL signal.
* In the README, I've suggested calling `start` before each example instead of before the whole suite. This is needed to reset the list of proxied requests between each example. It's safely idempotent, `start` will not start a new process if it already has one running. Existing code that calls `start` in `before(:suite)` should also continue working as before.
* Oh, also, the `chrome_switches` argument seems to be deprecated. The current way that works for me is to put `args` in `desiredCapabilities`. See https://sites.google.com/a/chromium.org/chromedriver/capabilities

Please let me know if you are interested in merging any of these changes back into the main branch, and if there's anything I can do to bring this code up to your standards. And, thank you for creating the wonderful and helpful tool `capybara-webmock`. :-)