### PR TITLE
Fix bug with proxying chunked encoding

### DIFF
--- a/lib/capybara/webmock/proxy.rb
+++ b/lib/capybara/webmock/proxy.rb
@@ -9,6 +9,11 @@ class Capybara::Webmock::Proxy < Rack::Proxy
     ensure_log_exists
   end
 
+  def call(env)
+    @streaming = true
+    super
+  end
+
   def perform_request(env)
     request = Rack::Request.new(env)
     allowed_urls = ['127.0.0.1', 'localhost', %r{(.*\.|\A)lvh.me}]
@@ -22,6 +27,12 @@ class Capybara::Webmock::Proxy < Rack::Proxy
 
   def self.remove_pid
     File.delete(PID_FILE) if File.exist?(PID_FILE)
+  end
+
+  def rewrite_response(triplet)
+    status, headers, body = triplet
+    headers.delete "transfer-encoding"
+    triplet
   end
 
   private

--- a/lib/capybara/webmock/version.rb
+++ b/lib/capybara/webmock/version.rb
@@ -1,5 +1,5 @@
 module Capybara
   module Webmock
-    VERSION = "0.4.0"
+    VERSION = "0.4.1"
   end
 end


### PR DESCRIPTION
There's an issue when proxying items that have chuncked encoding wherein you get an incomplete response. Reference below:

https://github.com/ncr/rack-proxy/issues/51
https://github.com/ncr/rack-proxy/issues/50

The changes in this PR made my test suite finally work.

Thanks for the nice gem! 👍 