### PR TITLE
Add support for Capybara versions greater than 2.4

### DIFF
--- a/capybara-webmock.gemspec
+++ b/capybara-webmock.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "capybara", "~> 2.4"
+  spec.add_dependency "capybara", ">= 2.4", "< 4"
   spec.add_dependency "rack", ">= 1.4"
   spec.add_dependency "rack-proxy", ">= 0.6.0"
   spec.add_dependency "selenium-webdriver", "~> 3.0"

--- a/lib/capybara/webmock/version.rb
+++ b/lib/capybara/webmock/version.rb
@@ -1,5 +1,5 @@
 module Capybara
   module Webmock
-    VERSION = "0.4.1"
+    VERSION = "0.4.2"
   end
 end


### PR DESCRIPTION
* Previously the Capybara version was locked at 2.4; this commit changes
the gem versioning to allow for Capybara versions greater than 2.4.

* This change allows users to continue using 2.4 if they're still on it
and also opens up the gem for users who want to utilize Capybara 3.*.

* Because this is backwards compatible I increased the gem version only
by a patch level from "0.4.1" to "0.4.2".