### PR TITLE
Fix deprecation warnings for Chrome

### DIFF
--- a/lib/capybara/webmock.rb
+++ b/lib/capybara/webmock.rb
@@ -34,7 +34,7 @@ module Capybara
         profile
       end
 
-      def chrome_switches
+      def chrome_options
         ["--proxy-server=127.0.0.1:#{port_number}"]
       end
 
@@ -52,7 +52,7 @@ Capybara.register_driver :capybara_webmock do |app|
 end
 
 Capybara.register_driver :capybara_webmock_chrome do |app|
-  Capybara::Selenium::Driver.new(app, browser: :chrome, switches: Capybara::Webmock.chrome_switches)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: Capybara::Webmock.chrome_options)
 end
 
 Capybara.register_driver :capybara_webmock_poltergeist do |app|

--- a/spec/capybara/webmock_spec.rb
+++ b/spec/capybara/webmock_spec.rb
@@ -5,8 +5,8 @@ describe Capybara::Webmock do
     Capybara::Webmock.firefox_profile.instance_variable_get("@additional_prefs")
   end
 
-  let(:chrome_switches) do
-    Capybara::Webmock.chrome_switches.first
+  let(:chrome_options) do
+    Capybara::Webmock.chrome_options.first
   end
 
   let(:phantomjs_options) do
@@ -17,17 +17,17 @@ describe Capybara::Webmock do
     expect(Capybara::Webmock::VERSION).not_to be nil
   end
 
-  describe '#chrome_switches' do
+  describe '#chrome_options' do
     it 'has an proxy flag' do
-      expect(chrome_switches).to include '--proxy-server='
+      expect(chrome_options).to include '--proxy-server='
     end
 
     it 'has an http proxy address' do
-      expect(chrome_switches).to include '127.0.0.1'
+      expect(chrome_options).to include '127.0.0.1'
     end
 
     it 'has an http proxy port' do
-      expect(chrome_switches).to include '9292'
+      expect(chrome_options).to include '9292'
     end
   end
 
@@ -88,7 +88,7 @@ describe Capybara::Webmock do
       end
 
       it 'changes the http port' do
-        expect(chrome_switches).to include '9988'
+        expect(chrome_options).to include '9988'
       end
     end
   end


### PR DESCRIPTION
The Capybara Selenium driver's `:args` and `:switches` arguments have been
deprecated in favor of `:options`. This change updates the Chrome
webmock setup to use the preferred setup format.