### PR TITLE
Fix broken options

### DIFF
--- a/lib/capybara/webmock.rb
+++ b/lib/capybara/webmock.rb
@@ -35,7 +35,9 @@ module Capybara
       end
 
       def chrome_options
-        ["--proxy-server=127.0.0.1:#{port_number}"]
+        ::Selenium::WebDriver::Chrome::Options.new.tap do |options|
+          options.add_argument("--proxy-server=127.0.0.1:#{port_number}")
+        end
       end
 
       def phantomjs_options

--- a/spec/capybara/webmock_spec.rb
+++ b/spec/capybara/webmock_spec.rb
@@ -6,7 +6,7 @@ describe Capybara::Webmock do
   end
 
   let(:chrome_options) do
-    Capybara::Webmock.chrome_options.first
+    Capybara::Webmock.chrome_options.args.first
   end
 
   let(:phantomjs_options) do


### PR DESCRIPTION
In 6609e73 the changes I proposed were incorrectly extracted from our
application, and resulted in an error when the driver would be booted
for a spec.

This change, tested directly against our application, resolves the issue
by passing the right kind of options object (a custom options object
rather than an array of arguments) to `Selenium::WebDriver::Chrome`.

After merging, we should release version 0.4.4 and yank 0.4.3, as it is
not usable.