### PR TITLE
Add headless driver for Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ or:
 ```ruby
 # Use Chrome Driver
 Capybara.javascript_driver = :capybara_webmock_chrome
+# or Chrome Driver in headless mode
+Capybara.javascript_driver = :capybara_webmock_chrome_headless
 ```
 
 ```ruby
@@ -88,7 +90,7 @@ Capybara.javascript_driver = :capybara_webmock_chrome
 Capybara.javascript_driver = :capybara_webmock_poltergeist
 ```
 
-*NOTE: These are just two default driver wrappers this gem provides. If you are
+*NOTE: These are just some default driver wrappers this gem provides. If you are
 already using a custom driver profile you can still use `capybara-webmock`, you
 just need to configure proxy settings to `127.0.0.1:9292`*
 

--- a/lib/capybara/webmock.rb
+++ b/lib/capybara/webmock.rb
@@ -68,7 +68,13 @@ module Capybara
       end
 
       def chrome_options
-        {args: [ "--proxy-server=127.0.0.1:#{port_number}" ]}
+        ::Selenium::WebDriver::Chrome::Options.new.tap do |options|
+          options.add_argument "--proxy-server=127.0.0.1:#{port_number}"
+        end
+      end
+
+      def chrome_headless_options
+        chrome_options.tap { |options| options.headless! }
       end
 
       def phantomjs_options
@@ -162,9 +168,11 @@ Capybara.register_driver :capybara_webmock do |app|
 end
 
 Capybara.register_driver :capybara_webmock_chrome do |app|
-  Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: {
-    chromeOptions: Capybara::Webmock.chrome_options
-  })
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: Capybara::Webmock.chrome_options)
+end
+
+Capybara.register_driver :capybara_webmock_chrome_headless do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: Capybara::Webmock.chrome_headless_options)
 end
 
 Capybara.register_driver :capybara_webmock_poltergeist do |app|

--- a/spec/capybara/webmock_spec.rb
+++ b/spec/capybara/webmock_spec.rb
@@ -9,8 +9,12 @@ describe Capybara::Webmock do
     Capybara::Webmock.firefox_profile.instance_variable_get("@additional_prefs")
   end
 
-  let(:chrome_args) do
-    Capybara::Webmock.chrome_options[:args].first
+  let(:chrome_options_args) do
+    Capybara::Webmock.chrome_options.args
+  end
+
+  let(:chrome_headless_options_args) do
+    Capybara::Webmock.chrome_headless_options.args
   end
 
   let(:phantomjs_options) do
@@ -21,24 +25,37 @@ describe Capybara::Webmock do
     expect(Capybara::Webmock::VERSION).not_to be nil
   end
 
-  describe '#chrome_args' do
+  describe '#chrome_options' do
     include Capybara::SpecHelper
 
     it 'has an proxy flag' do
-      expect(chrome_args).to include 'proxy-server='
-    end
-
-    it 'has an http proxy address' do
-      expect(chrome_args).to include '127.0.0.1'
-    end
-
-    it 'has an http proxy port' do
-      expect(chrome_args).to include '9292'
+      expect(chrome_options_args).to include '--proxy-server=127.0.0.1:9292'
     end
 
     it 'is used by the provided driver' do
       Capybara.server = :webrick
       session = Capybara::Session.new(:capybara_webmock_chrome, TestApp)
+
+      expect do
+        session.visit('/')
+      end.not_to raise_error
+    end
+  end
+
+  describe '#chrome_headless_options' do
+    include Capybara::SpecHelper
+
+    it 'has an proxy flag' do
+      expect(chrome_headless_options_args).to include '--proxy-server=127.0.0.1:9292'
+    end
+
+    it 'has a headless flag' do
+      expect(chrome_headless_options_args).to include '--headless'
+    end
+
+    it 'is used by the provided driver' do
+      Capybara.server = :webrick
+      session = Capybara::Session.new(:capybara_webmock_chrome_headless, TestApp)
 
       expect do
         session.visit('/')
@@ -103,7 +120,7 @@ describe Capybara::Webmock do
       end
 
       it 'changes the http port' do
-        expect(chrome_args).to include '9988'
+        expect(chrome_options_args).to include '--proxy-server=127.0.0.1:9988'
       end
     end
   end


### PR DESCRIPTION
Many developers prefer using Chrome for browser integration tests,
as Chrome is currently the most widely-used browser. And many
developers prefer headless browser integration tests, so they can
continue working while tests are running (running with a head only for
particularly complicated debugging). This adds a headless Chrome
driver for those developers.

Technical note:  This replaces the use of the `desired_capabilities` argument with the `options` argument when instantiating `Capybara::Selenium::Driver` for Chrome.  It passing an instance of`Selenium::WebDriver::Chrome::Options` as the value for `options`.  This seems to have become the new convention (for example, [Capybara itself is using it](https://github.com/teamcapybara/capybara/blob/master/lib/capybara.rb#L555)).

P.S. Thank you Hashrocket for maintaining this gem!