### PR TITLE
Use Forwardable in ProxiedRequest

### DIFF
--- a/lib/capybara/webmock/proxied_request.rb
+++ b/lib/capybara/webmock/proxied_request.rb
@@ -1,25 +1,19 @@
+require 'forwardable'
 require 'uri'
 
 module Capybara
   module Webmock
     class ProxiedRequest
+      extend Forwardable
+
       attr_reader :referrer, :uri
+
+      def_delegators :uri, :fragment, :host, :hostname, :password, :path, :port, :query, :scheme, :user, :userinfo
 
       def initialize(raw_referrer, raw_uri)
         @referrer = raw_referrer == "-" ? nil : URI.parse(raw_referrer)
         @uri = URI.parse(raw_uri)
       end
-
-      def fragment; @uri.fragment; end
-      def host; @uri.host; end
-      def hostname; @uri.hostname; end
-      def password; @uri.password; end
-      def path; @uri.path; end
-      def port; @uri.port; end
-      def query; @uri.query; end
-      def scheme; @uri.scheme; end
-      def user; @uri.user; end
-      def userinfo; @uri.userinfo; end
     end
   end
 end


### PR DESCRIPTION
This PR uses Forwardable to delegate to `@uri`.