### PR TITLE
Run tests with GitHub actions to ensure gem works with more versions of Ruby

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,0 @@
-version: 2
-jobs:
-  build:
-    docker:
-      - image: circleci/ruby:2.5.1-browsers
-    steps:
-      - checkout
-      - run: bundle install
-      - run: rake

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,20 @@
+name: Run tests
+
+on: [push]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
+        ruby: [2.5, 2.6, 2.7, '3.0', head]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - run: bundle exec rake

--- a/lib/capybara/webmock.rb
+++ b/lib/capybara/webmock.rb
@@ -70,6 +70,8 @@ module Capybara
       def chrome_options
         ::Selenium::WebDriver::Chrome::Options.new.tap do |options|
           options.add_argument "--proxy-server=127.0.0.1:#{port_number}"
+          options.add_argument('--headless')
+          options.add_argument('--disable-gpu')
         end
       end
 


### PR DESCRIPTION
Hey there hashrocketeers! 🚀 👋 

We've been using capybara-webmock and are currently upgrading our app to Ruby 3, but there 
are just a couple of things that are stopping it running on Ruby 3.

I've authored a quick PR here (https://github.com/hashrocket/capybara-webmock/pull/39) that fixes the issues 
if you're still welcoming contributions 👍 

As part of that, I've also used GitHub actions for running the tests, and ensuring the 
tests pass on more versions of Ruby, which is relatively easy using the GitHub actions 
matrix feature.

Here is that PR for migrating the CI system, if you're interested. GitHub actions makes things
a little more open for outside contributions and allows testing against multiple Ruby versions
so I think it's a nice use case, but up to you if you'd like to go for it 🙂 

Cheers!
Peter

---

### Changes

- Run on all major Ruby versions (and head) to ensure gem works with these versions.

- Add --disable-gpu and --headless options for compatibility on the GitHub
Actions ubuntu runner. Otherwise the chrome instance crashes on startup, because
it does not have an X server.

For the maintainer from hashrocket, I think you'll need to approve the action before
it'll run, as it's come from a fork 👍 