### PR TITLE
Require webrick and rexml to fix Ruby 3 LoadError issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,0 @@
-version: 2
-jobs:
-  build:
-    docker:
-      - image: circleci/ruby:2.5.1-browsers
-    steps:
-      - checkout
-      - run: bundle install
-      - run: rake

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,20 @@
+name: Run tests
+
+on: [push]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
+        ruby: [2.5, 2.6, 2.7, '3.0', head]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - run: bundle exec rake

--- a/capybara-webmock.gemspec
+++ b/capybara-webmock.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rack", ">= 1.4"
   spec.add_dependency "rack-proxy", ">= 0.6.0"
   spec.add_dependency "selenium-webdriver", "~> 3.0"
+  spec.add_dependency "rexml", ">= 3.2"
+  spec.add_dependency "webrick", ">= 1.7"
 
   spec.add_development_dependency "bundler", ">= 1.13"
   spec.add_development_dependency "pry", "~> 0.10.4"

--- a/lib/capybara/webmock.rb
+++ b/lib/capybara/webmock.rb
@@ -70,6 +70,8 @@ module Capybara
       def chrome_options
         ::Selenium::WebDriver::Chrome::Options.new.tap do |options|
           options.add_argument "--proxy-server=127.0.0.1:#{port_number}"
+          options.add_argument('--headless')
+          options.add_argument('--disable-gpu')
         end
       end
 


### PR DESCRIPTION
Prequel PR to migrate to GitHub actions to allow testing against Ruby 3:
https://github.com/hashrocket/capybara-webmock/pull/38

If you don't want to migrate from Circle CI to GitHub actions, we can drop those changes here and just not merge the other PR.

---

webrick is no longer a bundled gem in Ruby 3, and rexml is now a bundled
gem, rather than a default gem:
https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/

