### PR TITLE
Fixes for Ruby 3

### DIFF
--- a/capybara-webmock.gemspec
+++ b/capybara-webmock.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rack", ">= 1.4"
   spec.add_dependency "rack-proxy", ">= 0.6.0"
   spec.add_dependency "selenium-webdriver", "~> 3.0"
+  spec.add_dependency "rexml", ">= 3.2"
+  spec.add_dependency "webrick", ">= 1.7"
 
   spec.add_development_dependency "bundler", ">= 1.13"
   spec.add_development_dependency "pry", "~> 0.10.4"


### PR DESCRIPTION
webrick is no longer a bundled gem in Ruby 3, and rexml is now a bundled
gem, rather than a default gem:
https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/

