### PR TITLE
Allow use of selenium-webdriver 4.*

### DIFF
--- a/capybara-webmock.gemspec
+++ b/capybara-webmock.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "capybara", ">= 2.4", "< 4"
   spec.add_dependency "rack", ">= 1.4"
   spec.add_dependency "rack-proxy", ">= 0.6.0"
-  spec.add_dependency "selenium-webdriver", "~> 3.0"
+  spec.add_dependency "selenium-webdriver", ">= 3.0"
   spec.add_dependency "rexml", ">= 3.2"
   spec.add_dependency "webrick", ">= 1.7"
 


### PR DESCRIPTION
Previously this gem required selenium-webdriver 3.x, which means it
could not be used with selenium-webdriver gem is 4.x (first released
2021-10). This relaxes the requirement to 3+ so this gem can be used
with the latest version of seleniium-webdriver.

This PR is intended to resolve https://github.com/hashrocket/capybara-webmock/issues/44