### PR TITLE
Fix deprecation warnings for Chrome drivers

### DIFF
--- a/capybara-webmock.gemspec
+++ b/capybara-webmock.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "capybara", ">= 2.4", "< 4"
   spec.add_dependency "rack", ">= 1.4"
   spec.add_dependency "rack-proxy", ">= 0.6.0"
-  spec.add_dependency "selenium-webdriver", ">= 3.0"
+  spec.add_dependency "selenium-webdriver", ">= 4.0"
   spec.add_dependency "rexml", ">= 3.2"
   spec.add_dependency "webrick", ">= 1.7"
 

--- a/lib/capybara/webmock.rb
+++ b/lib/capybara/webmock.rb
@@ -174,11 +174,11 @@ Capybara.register_driver :capybara_webmock do |app|
 end
 
 Capybara.register_driver :capybara_webmock_chrome do |app|
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: Capybara::Webmock.chrome_options)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: [Capybara::Webmock.chrome_options])
 end
 
 Capybara.register_driver :capybara_webmock_chrome_headless do |app|
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: Capybara::Webmock.chrome_headless_options)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: [Capybara::Webmock.chrome_headless_options])
 end
 
 Capybara.register_driver :capybara_webmock_poltergeist do |app|


### PR DESCRIPTION
Since PR #45, a warning is being output to console when using selenium-webdriver 4+:
`:options as a parameter for driver initialization is deprecated.` This
implements the `:capabilities` array as instructed, and makes a
requirement of `selenium-webdriver` 4+ because 3 does not support the
capabilities syntax.

Related links:

- [Related capybara issue](https://github.com/teamcapybara/capybara/issues/2511)
- [Helpful StackOverflow post](https://stackoverflow.com/questions/69851082/how-do-i-correct-this-selenium-initialisation-command-deprecation-warning)

Using the `capabilities` syntax with selenium-webdriver 3.x (for example 3.142.7, the latest 3.x) raises an exception:
```
ArgumentError:
  unknown option: {:capabilities=>[#<Selenium::WebDriver::Chrome::Options:0x00007ffc4c0a2df0 @args=#<Set: {"--no-sandbox", "--headless"}>, @binary=nil, @prefs={}, @extensions=[], @options={}, @emulation={}, @detach=nil, @profile=nil, @encoded_extensions=[]>]}
```