### PR TITLE
Drop support for Ruby version 2.5 and earlier

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.5, 2.6, 2.7, '3.0', head]
+        ruby: [2.6, 2.7, '3.0', head]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/capybara-webmock.gemspec
+++ b/capybara-webmock.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/hashrocket/capybara-webmock'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version     = ">= 2.0.0"
+  spec.required_ruby_version     = ">= 2.6.0"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})


### PR DESCRIPTION
capybara-webmock now depends on selenium-webdriver 4.0, which requires at least Ruby 2.6.

See #48.
