### PR TITLE
Replace deprecated and removed File.exists? method with File.exist?

### DIFF
--- a/lib/capybara/webmock.rb
+++ b/lib/capybara/webmock.rb
@@ -123,7 +123,7 @@ module Capybara
       end
 
       def kill_old_process
-        return unless File.exists?(pid_file)
+        return unless File.exist?(pid_file)
         old_pid = File.read(pid_file).to_i
         kill_process(old_pid) if old_pid > 1
         remove_pid_file
@@ -152,13 +152,13 @@ module Capybara
       end
 
       def write_pid_file
-        raise "Pid file #{pid_file} already exists" if File.exists?(pid_file)
+        raise "Pid file #{pid_file} already exists" if File.exist?(pid_file)
         FileUtils.mkdir_p(File.dirname(pid_file))
         File.write(pid_file, @pid.to_s)
       end
 
       def remove_pid_file
-        File.delete(pid_file) if File.exists?(pid_file)
+        File.delete(pid_file) if File.exist?(pid_file)
       end
     end
   end

--- a/spec/capybara/webmock_spec.rb
+++ b/spec/capybara/webmock_spec.rb
@@ -139,7 +139,7 @@ describe Capybara::Webmock do
       written = []
       allow(File).to receive(:delete) { |path| written.delete(path) }
       allow(File).to receive(:write) { |path| written.push(path) }
-      allow(File).to receive(:exists?) { |path| written.include?(path) }
+      allow(File).to receive(:exist?) { |path| written.include?(path) }
 
       allow(Socket).to receive(:tcp)
 


### PR DESCRIPTION
`File.exists?` was deprecated in Ruby 2.1 and dropped in [Ruby 3.2](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/)

This PR replaces the deprecated/removed method with the new method.