### PR TITLE
Update development dependencies

### DIFF
--- a/capybara-webmock.gemspec
+++ b/capybara-webmock.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "webrick", ">= 1.7"
 
   spec.add_development_dependency "bundler", ">= 1.13"
-  spec.add_development_dependency "pry", "~> 0.10.4"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "pry", "~> 0.14.2"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "sinatra"


### PR DESCRIPTION
This prevents build failures on Ruby 3.2.
