### PR TITLE
Fix NoMethodError with headless Chrome 119+ (and deprecation warning with headless Chrome)

### DIFF
--- a/lib/capybara/webmock.rb
+++ b/lib/capybara/webmock.rb
@@ -80,7 +80,7 @@ module Capybara
       end
 
       def chrome_headless_options
-        chrome_options.tap { |options| options.headless! }
+        chrome_options.tap { |options| options.add_argument('--headless') }
       end
 
       def phantomjs_options

--- a/lib/capybara/webmock.rb
+++ b/lib/capybara/webmock.rb
@@ -80,7 +80,7 @@ module Capybara
       end
 
       def chrome_headless_options
-        chrome_options.tap { |options| options.add_argument('--headless') }
+        chrome_options.tap { |options| options.add_argument('--headless=new') }
       end
 
       def phantomjs_options


### PR DESCRIPTION
The selenium-webdriver gem's `headless!` method was deprecated, it now raises a warning.

This updates to use the recommended syntax. This new syntax is NOT compatible with Chrome versions before v109.

Additional details:

- Example warning: "WARN Selenium [:headless] [DEPRECATION] `Options#headless!` is deprecated. Use `Options#add_argument('--headless=new')` instead."
- Origin: [selenium-webdriver 4.8.0](https://github.com/SeleniumHQ/selenium/blob/trunk/rb/CHANGES) included change to "Deprecate #headless! for Chrome and Firefox"
- Resolution: `selenium-webdriver` suggests using `...=new`. That syntax is only appropriate for Chrome v109+ (meaning Chrome versions released 2023-01-10 onward). (See the [code comment](https://github.com/SeleniumHQ/selenium/commit/6c847fb19347af026bb630b127e8dd1a26f0a5e9#diff-941e8649970a94b0afc72051b81dbe7ed8180bcacdb71b3242bfe902255deed3R164) for details.)