### PR TITLE
Fix deprecation warning with Chrome capabilities

### DIFF
--- a/lib/capybara/webmock.rb
+++ b/lib/capybara/webmock.rb
@@ -174,11 +174,11 @@ Capybara.register_driver :capybara_webmock do |app|
 end
 
 Capybara.register_driver :capybara_webmock_chrome do |app|
-  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: [Capybara::Webmock.chrome_options])
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: Capybara::Webmock.chrome_options)
 end
 
 Capybara.register_driver :capybara_webmock_chrome_headless do |app|
-  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: [Capybara::Webmock.chrome_headless_options])
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: Capybara::Webmock.chrome_headless_options)
 end
 
 Capybara.register_driver :capybara_webmock_poltergeist do |app|


### PR DESCRIPTION
In selenium-webdriver 4.8.0, the `:capabilities` argument for Capybara::Selenium::Driver#new was deprecated and now raises a warning.

This updates the Capybara Chrome driver registrations to use updated syntax that does not raise a warning.

Additional details:

- Example warning: "WARN Selenium [:capabilities] [DEPRECATION] The :capabilities parameter for Selenium::WebDriver::Chrome::Driver is deprecated. Use :options argument with an instance of Selenium::WebDriver::Chrome::Driver instead. "
- Origin: [selenium-webdriver 4.8.0](https://github.com/SeleniumHQ/selenium/blob/trunk/rb/CHANGES) included change to "Deprecate support for :capabilities for local drivers".
- Revert: This reverts some of [PR #45](https://github.com/hashrocket/capybara-webmock/pull/46) (which I submitted 2022-02-07), because apparently selenium-webdriver reversed itself on using `capabilities` (it previously output a warning ":options as a parameter for driver initialization is deprecated.").