### PR TITLE
Add support for Rack 3 (fix "unable to connect")

### DIFF
--- a/lib/capybara/webmock/config.ru
+++ b/lib/capybara/webmock/config.ru
@@ -2,4 +2,5 @@ require 'rack'
 require 'capybara/webmock/proxy'
 
 app = Capybara::Webmock::Proxy.new(Process.pid)
-Rack::Handler::WEBrick.run(app, Port: ENV.fetch('CAPYBARA_WEBMOCK_PROXY_PORT_NUMBER', 9292))
+rack_handler = defined?(Rackup::Handler::WEBrick) ? Rackup::Handler::WEBrick : Rack::Handler::WEBrick
+rack_handler.run(app, Port: ENV.fetch('CAPYBARA_WEBMOCK_PROXY_PORT_NUMBER', 9292))


### PR DESCRIPTION
# Problem

Upgrading to Rack 3+ causes calls to `Capybara::Webmock.start` to fail with "RuntimeError: Unable to connect to capybara-webmock proxy on 9292" (followed by "EOFError: end of file reached" for subsequent tests in the rspec run).

That happens because [this gem's config.ru file](https://github.com/hashrocket/capybara-webmock/blob/master/lib/capybara/webmock/config.ru) calls `Rack::Handler::WEBrick`, which no longer exists as of Rack 3. It has been moved to Rackup (`Rackup::Handler::WEBrick`).

# Solution

This modifies config.ru to look for a new Rackup handler before falling back to an old Rack handler.

This uses the same syntax [used in capybara since 2023-10-08](https://github.com/teamcapybara/capybara/commit/49e3faf4b7d37957c51c3fc4bedd99c6f7bb1d05).

We missed the deprecation period because the warnings emitted in [stdout](https://github.com/hashrocket/capybara-webmock/blob/master/lib/capybara/webmock.rb#L26) don't get displayed. Likewise, now this is raising an error, we can't see the error messages. I found the problem by adding `puts stdout.read` and discovering the error message.